### PR TITLE
Positional Pattern Radius

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Typescript React component to generate a customizable QR Code.
 ```bash
 npm install --save react-qrcode-logo
 ```
-## Usage 
+## Usage
 
 ```javascript
 import * as React from 'react';
@@ -39,9 +39,55 @@ React.render(
 | `logoHeight`  | `number` (in pixels)                    | `logoWidth`                     | Logo image height |
 | `logoOpacity` | `number` (css opacity 0 <= x <= 1)      | `1`                    | Logo opacity. This allows you to modify the transparency of your logo, so that it won't compromise the readability of the QR Code |
 | `qrStyle` | `squares` &#124; `dots` | `squares`  | Style of the QR Code modules |
+| `eyeRadius` | `number | number[] | number[][]` | The corner radius for the positional patterns (the three "eyes" around the QR code). See more details below |
 
-## Example 
-You can find a very simple demo project [here](https://github.com/gcoro/QRCodeCustomizer). 
+## Example
+You can find a very simple demo project [here](https://github.com/gcoro/QRCodeCustomizer).
+
+## Positional Pattern Radius
+
+Give the positional pattern custom radii. You can either set one radius for all corners or all positional eyes, or
+specify a radius for each corner of each eye.
+
+Simple example:
+```jsx
+<QRCode
+	value="https://github.com/gcoro/react-qrcode-logo"
+	eyeRadius="5" // 5 pixel radius for all corners of all positional eyes
+/>
+```
+
+Other examples:
+
+```jsx
+// Radius for each eye
+eyeRadius={[
+	5,  // top/left eye
+	10, // top/right eye
+	5,  // bottom/left eye
+]}
+```
+
+```jsx
+// Radius for each corner (array is: top/left, top/right, bottom/right, bottom/left)
+eyeRadius={[
+	[10, 10, 0, 10], // top/left eye
+	[10, 10, 10, 0], // top/right eye
+	[10, 0, 10, 10], // bottom/left
+]}
+```
+
+```jsx
+// Include radius for the inner eye of the top/left eye
+eyeRadius={[
+	[   // top/left eye
+		[10, 10, 0, 10], // Outer ring
+		[0, 10, 10, 10], // Inner eye
+	],
+	[10, 10, 10, 0], // top/right eye
+	[10, 0, 10, 10], // bottom/left
+]}
+```
 
 ## Contributing
 Thanks to everyone who contributed :) PRs and suggestions are welcome.
@@ -74,5 +120,5 @@ Thanks to everyone who contributed :) PRs and suggestions are welcome.
 			</td></tr>
 </table>
 
-## More credits 
-This package was inspired by [cssivision/qrcode-react](https://github.com/cssivision/qrcode-react) and [zpao/qrcode.react](https://github.com/zpao/qrcode.react). Also looked up some parts from [kazuhikoarase/qrcode-generator](https://github.com/kazuhikoarase/qrcode-generator) (which this package depends on). 
+## More credits
+This package was inspired by [cssivision/qrcode-react](https://github.com/cssivision/qrcode-react) and [zpao/qrcode.react](https://github.com/zpao/qrcode.react). Also looked up some parts from [kazuhikoarase/qrcode-generator](https://github.com/kazuhikoarase/qrcode-generator) (which this package depends on).

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,4 +1,6 @@
 import * as React from 'react';
+declare type CornerRadii = number[];
+declare type CornerRadiusConfig = number | CornerRadii | CornerRadii[];
 export interface IProps {
     value?: string;
     ecLevel?: 'L' | 'M' | 'Q' | 'H';
@@ -11,6 +13,7 @@ export interface IProps {
     logoWidth?: number;
     logoHeight?: number;
     logoOpacity?: number;
+    eyeRadius?: number | CornerRadiusConfig;
     qrStyle?: 'squares' | 'dots';
     style?: object;
 }
@@ -18,7 +21,9 @@ export declare class QRCode extends React.Component<IProps, {}> {
     private canvas;
     static defaultProps: IProps;
     private static utf16to8;
+    private drawRoundedSquare;
     private drawPositioningPattern;
+    private isInPositioninZone;
     constructor(props: IProps);
     shouldComponentUpdate(nextProps: IProps): boolean;
     componentDidMount(): void;
@@ -35,3 +40,4 @@ export declare class QRCode extends React.Component<IProps, {}> {
         ref: React.RefObject<HTMLCanvasElement>;
     }, HTMLCanvasElement>;
 }
+export {};


### PR DESCRIPTION
I've added a new property `eyeRadius` radius to define the radii for the positional pattern eyes.

<img width="171" alt="Screen Shot 2021-07-21 at 9 28 44 AM" src="https://user-images.githubusercontent.com/35894/126529000-1adb82b2-ef9f-42b9-9dd4-aafc4a53591c.png">
<img width="166" alt="Screen Shot 2021-07-21 at 9 29 12 AM" src="https://user-images.githubusercontent.com/35894/126529013-42534be9-9e46-4ee0-b664-f2dbc67d421f.png">

This property allows multiple levels of control from one radius for all corners, to specifying the radius for each corner of the eye, inside and out.

```jsx
<QRCode
	value="https://github.com/gcoro/react-qrcode-logo"
	eyeRadius="5" // 5 pixel radius for all corners of all positional eyes
/>
```

```jsx
// Radius for each eye
eyeRadius={[
    5,  // top/left eye
    10, // top/right eye
    5,  // bottom/left eye
]}
```

```jsx
// Radius for each corner (array is: top/left, top/right, bottom/right, bottom/left)
eyeRadius={[
    [10, 10, 0, 10], // top/left eye
    [10, 10, 10, 0], // top/right eye
    [10, 0, 10, 10], // bottom/left
]}
```

```jsx
// Include radius for the inner eye of the top/left eye
eyeRadius={[
    [   // top/left eye
        [10, 10, 0, 10], // Outer ring
        [0, 10, 10, 10], // Inner eye
    ],
    [10, 10, 10, 0], // top/right eye
    [10, 0, 10, 10], // bottom/left
]}